### PR TITLE
fix bug in parallel backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,4 +48,4 @@ Edwin Tye (Edwin.Tye@phe.gov.uk)
 
 Version
 =======
-0.1.1 Improved parallel computation
+0.1.2 Pythonic class and function names

--- a/pygom/model/deterministic.py
+++ b/pygom/model/deterministic.py
@@ -16,8 +16,7 @@ from numbers import Number
 import numpy as np
 import sympy
 import scipy.linalg
-import matplotlib.image as mpimg
-import matplotlib.pyplot as plt
+
 from sympy.core.function import diff
 
 from .base_ode_model import BaseOdeModel
@@ -307,6 +306,8 @@ class DeterministicOde(BaseOdeModel):
         '''
         dot = _ode_composition.generateTransitionGraph(self, file_name)
         if show:
+            import matplotlib.image as mpimg
+            import matplotlib.pyplot as plt
             img = mpimg.imread(io.BytesIO(dot.pipe("png")))
             plt.imshow(img)
             plt.show(block=False)


### PR DESCRIPTION
There were issues because matplotlib was being loaded at the module level and it crashes machines/instances without graphics output capability.