### PR TITLE
Source directory was not correctly passed as argument in the windows batch file script.

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,10 +1,10 @@
 @ECHO OFF
 
 REM Command file for Sphinx documentation
-
 set SPHINXBUILD=sphinx-build
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set SPHINXOPTS=
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% source
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
 )


### PR DESCRIPTION
The sphinx-build was not being passed the source directory correctly when the parameter SPHINXOPTS was left unset. In all honesty, I do not know why this small change has fixed the bug, but I've tested this and it now builds the documentation when I run

```
cd pygom/doc
make html
```

from windows `cmd` or `powershell` in windows 10.
Note the Travis CI does not test this, so you may want to test this yourself if you have a windows computer available.