### PR TITLE
Adding Github actions as CI to verify Windows and MacOS

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,6 +68,7 @@ jobs:
                 }
           }
           Invoke-VSDevEnvironment
+          Get-Command rc.exe | Format-Table -AutoSize
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Check python version and install dependencies
+      - name: Check python version
         run: python -c "import sys; print(sys.version)"
         
       - name: RC.exe for Windows
@@ -75,21 +75,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install codecov
           
       - name: Build and install package for c files
         run: |
           python setup.py build
           python setup.py install
 
-      - name: Fix backend for matplotlib for MacOS
+      - name: Fix matplotlib backend for MacOS
         if: startsWith(runner.os, 'macOS')
         run: |
-          pwd
-          ls -lh
           mkdir ~/.matplotlib
           echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
 
-          
       - name: Test and coverage
-        run: coverage run setup.py test
+        run: python setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,6 +55,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
         
       - name: RC.exe for Windows
+        if: startsWith(runner.os, 'Windows')
         run: |
           function Invoke-VSDevEnvironment {
             $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,6 +54,20 @@ jobs:
       - name: Check python version and install dependencies
         run: python -c "import sys; print(sys.version)"
         
+      - name: RC.exe for Windows
+        run: |
+          function Invoke-VSDevEnvironment {
+            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+                  $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
+                  $Command = Join-Path $installationPath "Common7\Tools\vsdevcmd.bat"
+                & "${env:COMSPEC}" /s /c "`"$Command`" -no_logo && set" | Foreach-Object {
+                      if ($_ -match '^([^=]+)=(.*)') {
+                          [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+                      }
+                }
+          }
+          Invoke-VSDevEnvironment
+          
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -65,13 +79,14 @@ jobs:
           python setup.py build
           python setup.py install
 
-      - name: Fix backend for matplotlib
+      - name: Fix backend for matplotlib for MacOS
         if: startsWith(runner.os, 'macOS')
         run: |
           pwd
           ls -lh
           mkdir ~/.matplotlib
           echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
+
           
       - name: Test and coverage
         run: coverage run setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,6 +69,7 @@ jobs:
           }
           Invoke-VSDevEnvironment
           Get-Command rc.exe | Format-Table -AutoSize
+          echo "::add-path::$(Get-Command rc.exe | Split-Path)"
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,6 +21,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/cache@v1
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -39,8 +64,13 @@ jobs:
         run: |
           python setup.py build
           python setup.py install
+
+      - name: Fix backend for matplotlib
+        if: startsWith(runner.os, 'macOS')
+        run: |
           pwd
           ls -lh
+          mkdir ~/.matplotlib
           echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
           
       - name: Test and coverage

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           python setup.py build
           python setup.py install
+          pwd
+          ls -lh
+          echo "backend: TkAgg" >> ~/.matplotlib/matplotlibrc
           
       - name: Test and coverage
         run: coverage run setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,44 @@
+name: pygom
+
+on:
+  push:
+    branches:
+      - master
+      - release/*
+      - feature/*
+      - bugfix/*
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check python version and install dependencies
+        run: python -c "import sys; print(sys.version)"
+        
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install codecov
+          
+      - name: Build and install package for c files
+        run: |
+          python setup.py build
+          python setup.py install
+          
+      - name: Test and coverage
+        run: coverage run setup.py test

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pygom - ODE modelling in Python
 ===============================
 
-|Build status|  |Documentation Status|  |pypi version|  |licence|
+|Build status|  |Github actions|  |Documentation Status|  |pypi version|  |licence|
 
 .. |pypi version| image:: https://img.shields.io/pypi/v/pygom.svg
    :target: https://pypi.python.org/pypi/pygom
@@ -12,6 +12,8 @@ pygom - ODE modelling in Python
    :target: https://pygom.readthedocs.io/en/master/?badge=master
 .. |licence| image:: https://img.shields.io/pypi/l/pygom.svg   :alt: PyPI - License
    :target: https://raw.githubusercontent.com/PublicHealthEngland/pygom/master/LICENSE.txt
+.. |Github actions| image:: https://github.com/PublicHealthEngland/pygom/workflows/pygom/badge.svg
+   :target: https://github.com/PublicHealthEngland/pygom/actions/
 
 A generic framework for ode models, specifically compartmental type problems.
 


### PR DESCRIPTION
# Description
Due to issues such as https://github.com/PublicHealthEngland/pygom/issues/33, it became increasingly obvious that the current build via travis is insufficient as a form of *certification* of the library.  The reason is that a number of the users do not work in a Linux environment.

# Testing
Tests are replicated from TravisCI -> Github actions with two additional OS type in the form of Mac and Windows:
 https://github.com/edwintye/pygom/blob/d469ee2713124b7a5e10fac3e79abc3518356eff/.github/workflows/python.yml#L19

The addition OS require slight changes to how the environment is setup; changes to the installation processes are transparent as they are managed in CI.

# Observations
In the successful builds, it is obvious that the tests run significantly slow on Windows compared to the other two system.  This is probably of concern and should be investigated.
